### PR TITLE
6-29号问题修改

### DIFF
--- a/et --hard
+++ b/et --hard
@@ -1,0 +1,1082 @@
+[33mcommit 37f63228a6bddc48487c7d7b9e42fc3e5de2895b[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Wed Jun 28 11:36:31 2017 +0800
+
+    提交光标问题
+
+[33mcommit 43fdfd8ac59ee4984252b9a5185bd2129d7d628e[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Wed Jun 28 10:33:52 2017 +0800
+
+    字体样式修改
+
+[33mcommit 156e1dcde3c17431e86ba84d3468d4308eb957d6[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Tue Jun 27 22:35:05 2017 +0800
+
+    跟进部门问题修改
+
+[33mcommit 82de170e13500c36a462c302e45b3b10e5435741[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Tue Jun 27 22:32:53 2017 +0800
+
+    问题详情跟进部门问题修改
+
+[33mcommit 42cd75325a9b390bc7b01d253f4e5d36b1d3834f[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Tue Jun 27 19:35:36 2017 +0800
+
+    默认
+
+[33mcommit 535c2e8191fff7818af0cff4661631049e780f1c[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Tue Jun 27 18:01:37 2017 +0800
+
+    默认值修改和其它信息显示问题修改
+
+[33mcommit f07bacf4ba13aad90b14978fdbbe5dcc95b30819[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Tue Jun 27 17:18:47 2017 +0800
+
+    问题详情跟进方和采集接口类型修改
+
+[33mcommit b41adceb3bb242e0a436f66c5d55af1ed2864b40[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Tue Jun 27 15:40:10 2017 +0800
+
+    40，42问题修改
+
+[33mcommit 63b69cf961f3f781cc5206a175dd280770b52589[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Tue Jun 27 14:54:06 2017 +0800
+
+    保存返回改成以前的
+
+[33mcommit 29f3beac8eb64823c23f738c21c0530c8bdfb97f[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Tue Jun 27 11:16:06 2017 +0800
+
+    列表字体修改
+
+[33mcommit 09b33f795377d46884462fdb8387fee4d4877374[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Tue Jun 27 11:05:27 2017 +0800
+
+    cleanUrlStack修改
+
+[33mcommit 86add8854ea4142aa1593bf195ce6372da74c8cd[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Tue Jun 27 11:00:30 2017 +0800
+
+    加了一个跳转不带弹框的方法cleanUrlStack
+
+[33mcommit 9091b224fe3918cda68620c90e09f6b61daef175[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Tue Jun 27 10:27:31 2017 +0800
+
+    测试问题修改
+
+[33mcommit 8bd026c89908d28022e7f07a1252ca0c2f33aac8[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Mon Jun 26 22:46:43 2017 +0800
+
+    保存返回和滑动空太多的修改
+
+[33mcommit bff3ca1e3c23185f4d9eb751ef3106a75700bfff[m
+Merge: 99d4c65 2764496
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Mon Jun 26 19:45:08 2017 +0800
+
+    Merge branch 'devep' of https://github.com/cynthiamatthew/hdc into devep
+
+[33mcommit 99d4c65f444acdfe9edc5e46b6ed7987f8f82447[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Mon Jun 26 19:42:08 2017 +0800
+
+    隐藏原生的标题
+
+[33mcommit 261768c64fbff374708850aad80c1c76fb2b0de0[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Mon Jun 26 18:07:08 2017 +0800
+
+    问题详情跟进部门关联
+
+[33mcommit 27644963faced4b05f5a2ae8844e4df2bc7b8a0b[m
+Merge: ab4563d 5df10a4
+Author: thinkinerp <thinkinerp@users.noreply.github.com>
+Date:   Mon Jun 26 17:50:00 2017 +0800
+
+    Merge branch 'devep' into devep
+
+[33mcommit ab4563df00fb491ff8de8a60089e406a696364a8[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Mon Jun 26 16:06:14 2017 +0800
+
+    数据通除了41和1没改的所有问题修改
+
+[33mcommit 13d6a375a271351fb5017ca6c557d6f35516bd0e[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Mon Jun 26 14:11:33 2017 +0800
+
+    05，11，14，22，17，修改文字
+
+[33mcommit f90c8cde32792644258c4733bcce0c2e65445600[m
+Merge: 7dead2c 1c6885c
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Sun Jun 25 09:55:24 2017 +0800
+
+    Merge branch 'devep' of https://github.com/cynthiamatthew/hdc into devep
+
+[33mcommit 7dead2c8f448e2d2471ab5be37a14e4a58bc8e60[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Sun Jun 25 09:55:19 2017 +0800
+
+    01，11
+
+[33mcommit 5df10a4b8a6d43bf0261626ddab57b87df20b65f[m
+Author: zhai <328413963@qq.com>
+Date:   Sat Jun 24 18:59:07 2017 +0800
+
+    fix:安装，采集接口类型为硬件的时候，下面倒数第二行为硬件编号，写入数据库中的硬件编号；采集接口类型为软件的时候，下面倒数第二行为软件版本，写入数据库中的硬件编号；
+
+[33mcommit b6b79e418fa9d316e48aadc48924a00927009683[m
+Merge: 6f44c3c af31342
+Author: zhai <328413963@qq.com>
+Date:   Sat Jun 24 18:30:55 2017 +0800
+
+    config:解决 issueDetails.html 中的文件冲突
+
+[33mcommit 6f44c3c1e0835b04b06231bd9d0a3c867859479b[m
+Author: zhai <328413963@qq.com>
+Date:   Sat Jun 24 18:28:15 2017 +0800
+
+    fix:不小心打了一个空行
+
+[33mcommit af31342c856ecacb09c9d744e32a6da9f3e0b14d[m
+Merge: dd86c2c 1c6885c
+Author: thinkinerp <thinkinerp@users.noreply.github.com>
+Date:   Sat Jun 24 18:26:52 2017 +0800
+
+    Merge pull request #25 from cynthiamatthew/devep
+    
+    固定显示项目名称、筛选按钮
+
+[33mcommit 1c6885cbc50de04edddda3def2e482d2b756c8df[m
+Merge: b23b3c8 dd86c2c
+Author: thinkinerp <thinkinerp@users.noreply.github.com>
+Date:   Sat Jun 24 18:26:40 2017 +0800
+
+    Merge branch 'devep' into devep
+
+[33mcommit b23b3c8072d91925caaa000f4798d7d62679db82[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Sat Jun 24 17:48:04 2017 +0800
+
+    采集点只有一条安装信息，则默认该条
+
+[33mcommit 9f0a82fd9e967c1c4691030e83236338b693f24a[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Sat Jun 24 16:39:32 2017 +0800
+
+    标题栏样式修改
+
+[33mcommit 0be5aa46e3308c3c60ce833271e72155417563e9[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Sat Jun 24 16:11:12 2017 +0800
+
+    05,11,2214,15,18测试问题修改
+
+[33mcommit dd86c2cc0126b2855e7156b0fcdf4e2b0d5a76af[m
+Merge: a2181ec 4b93cdc
+Author: zhai <328413963@qq.com>
+Date:   Fri Jun 23 21:26:16 2017 +0800
+
+    合并王淑兰的代码
+
+[33mcommit a2181eca224e09494739514a029275c09c82015b[m
+Author: zhai <328413963@qq.com>
+Date:   Fri Jun 23 21:24:59 2017 +0800
+
+    fix:1.项目信息里面添加：客户对接人、客户对接人的联系方式.2.项目情况及项目问题，数值未正常显示，实际已建立2个安装点位，2个问题但已安装数量为0，问题数量为0。3.新建调研、安装的时候，选择商铺的时候区分已有单据的商铺和没有单据的商铺。
+
+[33mcommit cfd7424c6aeaf54279f676280dd4f56eafa8d010[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Fri Jun 23 16:42:18 2017 +0800
+
+    固定显示项目名称、筛选按钮
+
+[33mcommit 4b93cdc9b01d283049a9598983a6dfdd031ef6cb[m
+Merge: 2804a9c 6c13ffa
+Author: thinkinerp <thinkinerp@users.noreply.github.com>
+Date:   Fri Jun 23 13:25:46 2017 +0800
+
+    Merge pull request #24 from cynthiamatthew/devep
+    
+    fix左右滑动，添加商场内网
+
+[33mcommit 6c13ffaedc9bda55cc928065b9aebbdf5a8b6cb7[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Fri Jun 23 12:27:30 2017 +0800
+
+    fix左右滑动，添加商场内网
+
+[33mcommit 2804a9c402b1fbaaf3683e28bffcbc29a45b58c4[m
+Merge: fa4425d e87d4f4
+Author: zhai <328413963@qq.com>
+Date:   Thu Jun 22 20:37:08 2017 +0800
+
+    merge:合并王淑兰代码，并解决冲突
+
+[33mcommit fa4425d2013c476915775e0945e2579c0a03b9d6[m
+Author: zhai <328413963@qq.com>
+Date:   Thu Jun 22 20:32:59 2017 +0800
+
+    fix:项目汇总的 sql 语句不正确
+
+[33mcommit e87d4f43d0f4b0a1e889c7f9aab15eb6a4019516[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Thu Jun 22 20:18:46 2017 +0800
+
+    保存测试
+
+[33mcommit c723ed32c5876da7aaeaaa66db9c4c833068004f[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Thu Jun 22 20:02:59 2017 +0800
+
+    保存
+
+[33mcommit e66ed4159b3c35c7fcb11dab024e4a6c88eb61bb[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Thu Jun 22 19:37:03 2017 +0800
+
+    保存返回第二次
+
+[33mcommit f018a762d75fd15aad85ce1fa66515a2e11bc52e[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Thu Jun 22 19:34:58 2017 +0800
+
+    保存返回修改
+
+[33mcommit 0d923630ddb5e45b2a34f8c9da8fbd2b123a44bf[m
+Merge: dc046f4 36ea08d
+Author: thinkinerp <thinkinerp@users.noreply.github.com>
+Date:   Thu Jun 22 18:01:14 2017 +0800
+
+    Merge pull request #22 from cynthiamatthew/devep
+    
+    保存返回
+
+[33mcommit 36ea08d51ea9dcf923eb15832d6685e41cd31a2d[m
+Merge: 4892687 dc046f4
+Author: thinkinerp <thinkinerp@users.noreply.github.com>
+Date:   Thu Jun 22 18:01:00 2017 +0800
+
+    Merge branch 'devep' into devep
+
+[33mcommit feb493c8563d25943c06d1ffb587801e1af0b7ee[m
+Author: zhai <328413963@qq.com>
+Date:   Wed Jun 21 14:22:46 2017 +0800
+
+    fix:整理项目目录，将微信相关的文件全部删除
+
+[33mcommit dc046f481fe6df1f64ce893592dabbf6632846ec[m
+Author: zhai <328413963@qq.com>
+Date:   Tue Jun 20 09:44:29 2017 +0800
+
+    fix:1.安装中的网络环境修改为多选。2.安装中是安装编号对应错误。3.安装列表的 sql 语句关联条件出先问题，equipment 表没有和 install 表相关联。4.安装、调研、问题的 gotomodify 接口中使用了 shopMapper 的 selectByWhere 方法，这个方法和安装表做了关联，所以没有新建安装的门店不能取出来。为了解决这个问题，新建了 selectShops 方法，对 shops 单表进行 select 操作
+
+[33mcommit 4892687845b1f2bc1fa2ca9fd88542970f644267[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Mon Jun 19 16:27:06 2017 +0800
+
+    验证
+
+[33mcommit fc43e3a562862bff4f6904c914596278d870fa16[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Mon Jun 19 14:39:37 2017 +0800
+
+    安装
+
+[33mcommit 3ceadca4134e15b9259cdb950ed70c25bfa43a75[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Mon Jun 19 14:26:40 2017 +0800
+
+    调研和安装的修改
+
+[33mcommit 00c0b4813277a39399cfe1e57563037927b3faed[m
+Author: zhai <328413963@qq.com>
+Date:   Sun Jun 18 17:46:49 2017 +0800
+
+    feature:登陆页面添加
+
+[33mcommit b7e94ed2f0e884239d87810e77ca9040b9722498[m
+Author: zhai <328413963@qq.com>
+Date:   Sun Jun 18 00:00:41 2017 +0800
+
+    feature:实现功能：项目信息、商铺信息、用户信息、状态信息的导入
+
+[33mcommit 6cf7e1ae736277a29e03f2cf80c3971b0ea1750b[m
+Merge: 450463f 17c8689
+Author: thinkinerp <thinkinerp@users.noreply.github.com>
+Date:   Fri Jun 16 16:49:20 2017 +0800
+
+    Merge pull request #19 from cynthiamatthew/devep
+    
+    会员信息对勾显示
+
+[33mcommit 17c8689c40ed70430c004280273ad110a164ac9e[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Fri Jun 16 16:45:36 2017 +0800
+
+    会员信息对勾显示
+
+[33mcommit 450463fadc106d7431d6e6149a5fe996bd9441a3[m
+Merge: d7e346e 3458e24
+Author: thinkinerp <thinkinerp@users.noreply.github.com>
+Date:   Fri Jun 16 16:12:36 2017 +0800
+
+    Merge pull request #18 from cynthiamatthew/devep
+    
+    图片和验证
+
+[33mcommit 3458e24cc1fe398482cb16345075e0ae0b20ee57[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Fri Jun 16 16:10:24 2017 +0800
+
+    图片和验证
+
+[33mcommit d7e346e9b2cb83c31341c7a7b711013b6925d77a[m
+Merge: 15f89db 4d558a4
+Author: zhai <328413963@qq.com>
+Date:   Fri Jun 16 15:30:31 2017 +0800
+
+    fix:新建调研，填写了打印机型号后，在没有填写打印机编号的情况下，单据也保存了
+
+[33mcommit 15f89db19d63784a2becdbe0135b6980a4ef6824[m
+Author: zhai <328413963@qq.com>
+Date:   Fri Jun 16 15:27:22 2017 +0800
+
+    fix:test
+
+[33mcommit 4d558a40e116821df69cba2c561090fafbbd2635[m
+Merge: 45347b2 a9f47ef
+Author: thinkinerp <thinkinerp@users.noreply.github.com>
+Date:   Fri Jun 16 15:13:51 2017 +0800
+
+    Merge pull request #17 from cynthiamatthew/devep
+    
+    会员信息
+
+[33mcommit 45347b2c8c865fc9f6221b079a4ccd36c90dd16a[m
+Merge: 61c3c30 88b44dd
+Author: thinkinerp <thinkinerp@users.noreply.github.com>
+Date:   Fri Jun 16 15:13:08 2017 +0800
+
+    Merge pull request #16 from cynthiamatthew/devep
+    
+    验证修改
+
+[33mcommit a9f47efb8aa02ec72326391fbe8e36158c12b5c9[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Fri Jun 16 15:12:02 2017 +0800
+
+    会员信息
+
+[33mcommit 88b44dd00b1aea542bf22856b8fccd91f734d983[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Fri Jun 16 14:58:46 2017 +0800
+
+    验证修改了一下
+
+[33mcommit 137517ef0c2c955166410691e90aa0657934268e[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Fri Jun 16 14:48:55 2017 +0800
+
+    验证提交
+
+[33mcommit 61c3c3021acca8703e2a91a8de3ca06467998d4d[m
+Author: zhai <328413963@qq.com>
+Date:   Fri Jun 16 12:32:08 2017 +0800
+
+    fix:update 调研信息的时候，没有将 vip_info 字段写到 SQL 语句中
+
+[33mcommit caa79fcbcbe05f7279be8bbf3ec3425710249cbd[m
+Merge: 1d73278 6204e81
+Author: thinkinerp <thinkinerp@users.noreply.github.com>
+Date:   Fri Jun 16 11:47:48 2017 +0800
+
+    Merge pull request #15 from cynthiamatthew/devep
+    
+    图片测试div删除
+
+[33mcommit 6204e81f608f1add6b77dc1f090a6cd3829add10[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Fri Jun 16 11:23:02 2017 +0800
+
+    图片测试div删除
+
+[33mcommit 1d7327821e8e05ee03eec2000a44e24c4e7f52ad[m
+Merge: 13e0976 72848e1
+Author: thinkinerp <thinkinerp@users.noreply.github.com>
+Date:   Fri Jun 16 11:15:38 2017 +0800
+
+    Merge pull request #14 from cynthiamatthew/devep
+    
+    图片问题
+
+[33mcommit 72848e1ec693e1ed83d5d7bd68433c9d98567c15[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Fri Jun 16 11:12:06 2017 +0800
+
+    图片问题修正2
+
+[33mcommit ffee1d885b408f531fb307c5a69d9625b286f302[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Fri Jun 16 10:54:20 2017 +0800
+
+    图片问题
+
+[33mcommit 13e0976a55c83e26dfb289a5310e94d26d3df93a[m
+Merge: 7c32489 c85a3f9
+Author: thinkinerp <thinkinerp@users.noreply.github.com>
+Date:   Fri Jun 16 07:58:36 2017 +0800
+
+    Merge pull request #13 from cynthiamatthew/devep
+    
+    问题详情图片问题修正
+
+[33mcommit c85a3f9e8457507c094d409d6f13f0f5688b9da0[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Fri Jun 16 07:53:58 2017 +0800
+
+    问题详情图片问题修正
+
+[33mcommit 7c324895386b5adc17f43587a83324ef0746185e[m
+Merge: fdcc8f5 cc07ba4
+Author: thinkinerp <thinkinerp@users.noreply.github.com>
+Date:   Thu Jun 15 22:38:13 2017 +0800
+
+    Merge pull request #12 from cynthiamatthew/devep
+    
+    调研详情图片
+
+[33mcommit cc07ba4ecda20bfec003c2e8089a5d1c26e27736[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Thu Jun 15 22:35:28 2017 +0800
+
+    调研详情图片
+
+[33mcommit fdcc8f5799c06447cd8a16718f1e31330ee75914[m
+Merge: b7ad30d 29d3b83
+Author: thinkinerp <thinkinerp@users.noreply.github.com>
+Date:   Thu Jun 15 19:49:31 2017 +0800
+
+    Merge pull request #11 from cynthiamatthew/devep
+    
+    详情会员信息
+
+[33mcommit 29d3b83dbf0e9d93461f8a2716f45dbb6749312d[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Thu Jun 15 19:40:47 2017 +0800
+
+    会员信息验证空的时候默认为未选择
+
+[33mcommit 4f0e963e17ab96eebe521863206404e70dcd52e7[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Thu Jun 15 19:15:36 2017 +0800
+
+    调研详情会员信息验证修改
+
+[33mcommit 3c13259dbd4536c1c7d566c36f645c49d4b64b04[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Thu Jun 15 19:13:37 2017 +0800
+
+    调研详情会员信息的显示
+
+[33mcommit b7ad30de1ed1b7b11e8897caa6711248c8382f50[m
+Merge: 31704e0 cb92936
+Author: thinkinerp <thinkinerp@users.noreply.github.com>
+Date:   Thu Jun 15 17:26:12 2017 +0800
+
+    Merge pull request #10 from cynthiamatthew/devep
+    
+    用户信息验证修改
+
+[33mcommit cb929366dca512c9f978df4a7d82b32450de6ddd[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Thu Jun 15 17:21:08 2017 +0800
+
+    用户信息验证修改
+
+[33mcommit 31704e0c9baa2390b76d95c4e98cf76bba7eea5a[m
+Merge: ef1e4b4 0bdf454
+Author: thinkinerp <thinkinerp@users.noreply.github.com>
+Date:   Thu Jun 15 17:10:38 2017 +0800
+
+    Merge pull request #9 from cynthiamatthew/devep
+    
+    复选框图片
+
+[33mcommit 0bdf454142af32a44d90d6710329aa1ca212abb9[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Thu Jun 15 17:08:01 2017 +0800
+
+    复选框图片
+
+[33mcommit ef1e4b4d1a350924732a59087151b4a8b661a506[m
+Merge: 2b889ff 586bf21
+Author: thinkinerp <thinkinerp@users.noreply.github.com>
+Date:   Thu Jun 15 16:10:06 2017 +0800
+
+    Merge pull request #8 from cynthiamatthew/devep
+    
+    新加会员信息
+
+[33mcommit 586bf21f97e2ad27f7bb8b8bb3b1b2ca0f2e2ead[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Thu Jun 15 16:08:07 2017 +0800
+
+    新加会员信息
+
+[33mcommit 2b889ff5ca750aa5939752ffb4c2ec2590df57c6[m
+Merge: eacd1a6 3ca775f
+Author: thinkinerp <thinkinerp@users.noreply.github.com>
+Date:   Thu Jun 15 15:42:29 2017 +0800
+
+    Merge pull request #7 from cynthiamatthew/devep
+    
+    测试问题修正
+
+[33mcommit 3ca775f4d5a9e13e0281936c4b5b7115a675e101[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Thu Jun 15 15:33:49 2017 +0800
+
+    测试问题修正
+
+[33mcommit eacd1a6eb12c59bca9c9217e6a6c4996cb1da3cd[m
+Merge: 8d283b0 108fc3f
+Author: thinkinerp <thinkinerp@users.noreply.github.com>
+Date:   Wed Jun 14 21:51:51 2017 +0800
+
+    Merge pull request #6 from cynthiamatthew/devep
+    
+    验证修改
+
+[33mcommit 108fc3fa7330ef4cfdfac81ffb4f5b433fc38f1d[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Wed Jun 14 21:49:58 2017 +0800
+
+    验证修改
+
+[33mcommit 8d283b06d1d2c92962a18265ee55467a9eba2d4e[m
+Merge: 6a2ae26 72d42a6
+Author: thinkinerp <thinkinerp@users.noreply.github.com>
+Date:   Wed Jun 14 21:08:49 2017 +0800
+
+    Merge pull request #5 from cynthiamatthew/devep
+    
+    验证修改
+
+[33mcommit 72d42a6f00145d3cd0003458ce33b8527603cee2[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Wed Jun 14 21:05:17 2017 +0800
+
+    验证修改
+
+[33mcommit 6a2ae2652401384fe10fa626e1a9a2e2b3eabb67[m
+Merge: 999d05a 8e84d7e
+Author: thinkinerp <thinkinerp@users.noreply.github.com>
+Date:   Wed Jun 14 20:45:35 2017 +0800
+
+    Merge pull request #4 from cynthiamatthew/devep
+    
+    编号自动读取
+
+[33mcommit 8e84d7e90d6174a13fbaec38c18b495a873187bd[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Wed Jun 14 20:42:20 2017 +0800
+
+    编号自动读取
+
+[33mcommit 999d05a84aeee241721b5190b9d88fd5111ef576[m
+Merge: 20b2d86 d9f3904
+Author: zhai <328413963@qq.com>
+Date:   Wed Jun 14 20:23:32 2017 +0800
+
+    feature:单据编号自动生成功能
+
+[33mcommit d9f390480c9ab592f4e817ad2163c6ba54749cb7[m
+Merge: f961ebb d71644c
+Author: thinkinerp <thinkinerp@users.noreply.github.com>
+Date:   Wed Jun 14 20:20:50 2017 +0800
+
+    Merge pull request #3 from cynthiamatthew/devep
+    
+    修改验证
+
+[33mcommit d71644c4c98a6c2e134c0fb3b31998c6e26b2c0e[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Wed Jun 14 20:14:56 2017 +0800
+
+    修改验证
+
+[33mcommit 20b2d86670670d8662c418877676c1c210dc0ebb[m
+Merge: ac2c8b5 f961ebb
+Author: zhai <328413963@qq.com>
+Date:   Wed Jun 14 19:00:59 2017 +0800
+
+    fix:数据通问题
+
+[33mcommit ac2c8b5d5b2585791833c7369dc6d1c88ec5ff2d[m
+Author: zhai <328413963@qq.com>
+Date:   Wed Jun 14 18:59:23 2017 +0800
+
+    fix:数据通列表
+
+[33mcommit f961ebb0142e925f2c45ffb29ecb1497187c4a42[m
+Merge: 0689e37 70671e0
+Author: thinkinerp <thinkinerp@users.noreply.github.com>
+Date:   Wed Jun 14 18:57:16 2017 +0800
+
+    Merge pull request #2 from cynthiamatthew/devep
+    
+    数据通的验证相关问题修改
+
+[33mcommit 70671e06f90104bc8d687518ffc4b97dcea47d89[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Wed Jun 14 17:34:06 2017 +0800
+
+    数据通的验证相关问题修改
+    
+    数据通的验证相关问题修改
+
+[33mcommit 0689e371b963dbcabb6d145cb7a56c440c978ecc[m
+Merge: fc6ddd4 56b4427
+Author: thinkinerp <thinkinerp@users.noreply.github.com>
+Date:   Tue Jun 13 23:46:15 2017 +0800
+
+    Merge pull request #1 from cynthiamatthew/devep
+    
+    修改测试
+
+[33mcommit 56b4427ab4f742c7a8a981ed8e3181e04e73d53c[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Tue Jun 13 15:48:13 2017 +0800
+
+    修改样式
+
+[33mcommit 3e496219653941acb98edb88b8d42d2141c3addb[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Tue Jun 13 08:37:56 2017 +0800
+
+    修改按钮样式
+
+[33mcommit 677e8dd9c5f954c83d784080cd19a0f7a839a52e[m
+Author: cynthiamatthew <wangshulan@andoner.com>
+Date:   Mon Jun 12 18:04:32 2017 +0800
+
+    修改测试
+
+[33mcommit fc6ddd46c09229fd81a326407c3ca43c21b44a1a[m
+Author: zhai <328413963@qq.com>
+Date:   Mon Jun 12 14:37:12 2017 +0800
+
+    fix:时间较长忘记了
+
+[33mcommit 57d194a28a8714859f8b754b5c196cab367dc0cd[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Mon Jun 5 15:32:48 2017 +0800
+
+    fix:拍照加载图片后，图片逆时针方向旋转 90 度
+
+[33mcommit 56b5cb31da8a27c9018de526c1ddb5cae66913cf[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Sun Jun 4 19:48:45 2017 +0800
+
+    fix:弹出框标题文字放到搜索框中
+
+[33mcommit 7ab332b91b7f501dca5ae9ed52b12bf9f5517f5d[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Sun Jun 4 19:33:27 2017 +0800
+
+    fix:android 版本，新建、保存、取消等按钮会在呼出键盘的时候漂移到键盘的上方，影响操作体验
+
+[33mcommit 9edcdfeb0cca548737f84c35fa303abb4fb11e35[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Sun Jun 4 19:29:09 2017 +0800
+
+    fix:解决拍照不能上传图片的问题，先设置了 maxUploadFile 的大小没有成功，后来在网上找了其他的解决方案，也没有解决，最后是将图片进行将值
+
+[33mcommit 69d05e22e524da777fb70f0b631f7f04ee4c3166[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Sat Jun 3 16:02:19 2017 +0800
+
+    fix:将前段代码分离到 sjt 文件夹下，并且删除了没有用的文件和文件夹，以后前端 copy sjt 这个文件夹即可工作
+
+[33mcommit c7244cb597753bd6fe256e606afabed13495431b[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Thu Jun 1 13:49:47 2017 +0800
+
+    fix:1.为调研、项目、安装列表页面添加模糊查询。2.采集点类型地段对应错误。3.重新选择项目名称 但是商铺名称没有变。4.调研列表，搜索后插入上次项目名称
+
+[33mcommit 38d64069c9861d53bc9e85f4f5e36c9fcfb25237[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Wed May 31 07:37:31 2017 +0800
+
+    fix:校对项目汇总的 SQL
+
+[33mcommit 66478ebdd9ff62849c9f3c34567d1e282cb6ef77[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Mon May 29 20:49:13 2017 +0800
+
+    feature:将项目的两个页面修改成了 HTML 静态页面
+
+[33mcommit 40f1b05a915501808655e3f96375993389d2436d[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Mon May 29 20:07:55 2017 +0800
+
+    feature:将安装的两个页面修改成了 html 静态页面
+
+[33mcommit faaace8397d2b9db918fde077fa76bdf997f8e7d[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Mon May 29 16:27:07 2017 +0800
+
+    feature:在安装列表页面中，添加了下面的功能：1.在弹出框中，添加标题。2.添加为下拉框添加 placehold 功能，为 div 添加 defaultVal 属性配合 getValue 函数来实现的
+
+[33mcommit fd968db3df88b40c2c5efb586d62fb95a54bf359[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Fri May 26 17:12:34 2017 +0800
+
+    fix:在各个列表页面，添加了记住上次选择项目的逻辑
+
+[33mcommit 094fef0609e01b9f0458eadaaccb71df14353585[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Fri May 26 16:51:54 2017 +0800
+
+    fix:检验打印机、收银机、采集点、安装、调研、问题编号的合法性检验，规则是只能有英文字母和数字组合而成
+
+[33mcommit b4f6508c7c0ad6724e40baeaa673bcefe1741fbf[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Fri May 26 16:29:19 2017 +0800
+
+    fix:将所有的弹出框都改为可搜索
+
+[33mcommit c1e299f47c7f5245ce3bce510710bbdddaefc879[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Fri May 26 16:09:17 2017 +0800
+
+    fix:将上次在调研模块实现的图片上传功能移植到问题、安装模块
+
+[33mcommit 6ed02dc4603af51e5f602752545fac9fcc739c74[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Fri May 26 15:59:39 2017 +0800
+
+    fix:应付以下情况，1.删除图片。2.替换图片。3.添加图片
+
+[33mcommit 7072a5962904a84312f0b7cfafd08e8537b356c6[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Fri May 26 09:51:24 2017 +0800
+
+    fix:修复bug
+
+[33mcommit e22f3d25262b4562a4eb06e1b23b0f97396544eb[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Mon May 22 07:08:08 2017 +0800
+
+    fix:shopController.selectForCombobox 传参命名错误，proId 被当成 proName
+
+[33mcommit 9cca0a7a1ab15062a7ad5e289e8679bfc44d3388[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Sun May 21 21:46:34 2017 +0800
+
+    fix:projectMapper.selectByWhere 中没有 proId 这个参数导致，项目列表中的数据和项目参数对不上
+
+[33mcommit 0c4d63dd852ab2d6730ea37d85112b86d613ce42[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Sun May 21 20:15:12 2017 +0800
+
+    feature:新增用户行为记录功能
+
+[33mcommit 03212f0a5ff79c11f5e325e5da43f3090e6a34cd[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Sun May 21 18:22:46 2017 +0800
+
+    feature:1.增加了编码唯一性检查。2.增加了编码能不为空检查。3.增加了编码只能由数字和英文字母组成的检验
+
+[33mcommit 95b9f3f3f8acb79c43895736ec737b6b949d5f69[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Fri May 19 09:37:40 2017 +0800
+
+    fix:problemController 中的 gotoModify 方法中增加了判断打印机或者收银机是否为空的逻辑
+
+[33mcommit fc2be0d1f73db8dda11e34fca13d246fa685f707[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Fri May 19 07:04:40 2017 +0800
+
+    feature:完成了问题页的批注功能
+
+[33mcommit e5dedd7ecbd0ee3b7af52a77687cf0695fdd625c[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Thu May 18 20:09:07 2017 +0800
+
+    fix:修复 suiveyController 中返回 json 格式不正确的问题
+
+[33mcommit e4757d363216706e415d059ec77491a4ff6465ae[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Thu May 18 16:06:32 2017 +0800
+
+    fix:问题页面的图片上传、修改、新增功能
+
+[33mcommit f28c81a14e7e8e243cb28420cba558f8b209d3db[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Wed May 17 16:51:51 2017 +0800
+
+    feature:为问题、调研、安装模块中的新建修改功能加上保存图片的功能
+
+[33mcommit d7a5003d8e9f0127e4af7a06242b8c400561174d[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Wed May 17 16:41:49 2017 +0800
+
+    feature:1.添加批注的增加、查询接口。2.添加了安装的上传图片功能
+
+[33mcommit d507cb3b05cd5c2bc71c1311b79207905e54042e[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Wed May 17 14:02:17 2017 +0800
+
+    fix:修复 controller 层中的 submit 和 modify 方法为 post 类型，并支持了图片的上传
+
+[33mcommit 57e83ca5caacc867855f3d0175b3704d555392b5[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Mon May 15 14:45:37 2017 +0800
+
+    fix:/survey/gotoModify 1.接口返回的 json 格式不正确，toJSONString 以后又进行了一次同样的操作。2.上传图片功能，将图片的 base64 格式的存到 array 然后，JSON.parse(array),传到后台，使用 jsonArray 接收
+
+[33mcommit 6dfadbf86c2cefdc35773287a6de22a0b26d40be[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Sun May 14 11:07:09 2017 +0800
+
+    feature 图片上传功能完善，遗留的 BUG：选择图片是一次选两张图片的时候，才能上传两张图片，一张一张的选择图片，只能上传上次选择的图片
+
+[33mcommit b95c6b958731f69b304636570a3fa6b513673943[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Fri May 12 09:00:59 2017 +0800
+
+    feature:添加问题的后台接口
+
+[33mcommit 9a8ffc2154d142d660f84d8ff59d56a23df70f3f[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Thu May 11 15:15:09 2017 +0800
+
+    fix:修复安装问题
+
+[33mcommit b0b53dd2666c17cb3e28a101d44c6c8cc20854c6[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Wed May 10 17:36:32 2017 +0800
+
+    feature:增加了安装、调研、批注、项目记录功能
+
+[33mcommit 54eccc080e4ca85413a36e4d282432e95698d94e[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Fri May 5 12:00:19 2017 +0800
+
+    feature:添加调研、安装、跟踪、项目的 mapper、vo
+
+[33mcommit eafbeeeb25ad9e5662699e155c561f9d728a4bca[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Tue May 2 16:59:50 2017 +0800
+
+    config:修改配置文件
+
+[33mcommit fd305ac89ff8bf98195d6ab818d8e964fcd8ffa6[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Tue May 2 13:49:46 2017 +0800
+
+    fix:修复根路径 StaticVariableUtil.BASE_URL 使用不当
+
+[33mcommit 63d603acc3763186bb3e941ccf0b6696db0227d4[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Fri Apr 28 11:31:50 2017 +0800
+
+    fix:dataCommunicationController.checkOnUser,在用户没有和任何门店绑定时候，没有将门店名称保存在 session 中
+
+[33mcommit d4aec12d9822b3862c3261439c9af146351ea4af[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Fri Apr 28 11:22:32 2017 +0800
+
+    fix:WeiXinUserInfoUtiil.getSign 方发的参数调用错误
+
+[33mcommit 3762c18d6f754920d39965e4233488356030a560[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Fri Apr 28 11:18:52 2017 +0800
+
+    feature:门店绑定功能
+
+[33mcommit 5eba519453f80f097f892eec469b88bfc571e5fb[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Wed Apr 26 19:23:33 2017 +0800
+
+    feature:扫码接口调用
+
+[33mcommit 6227829949d7c1c194afeab12ae490d1dc0590ed[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Tue Apr 25 22:15:43 2017 +0800
+
+    feature: 扫码提报过程，增加重新绑定门店功能
+
+[33mcommit 7293ff8471a8b049d4151cb06f92c35515faf31d[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Tue Apr 25 20:10:45 2017 +0800
+
+     first commit
+
+[33mcommit e2c38fc5cfd06382b902db70b3d7a108e489423d[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Mon Feb 27 14:19:24 2017 +0800
+
+    fix(rc/main/java/org/wang/tools/controller/ToolsController.java): make sql lowcase
+
+[33mcommit 55efe0baa3cb140e6583ea04ec9fbe95d670e813[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Tue Feb 21 11:26:42 2017 +0800
+
+    fix(src/main/java/org/wang/tools/controller/ToolsController.java)): district, class, dept .equal -> contains
+
+[33mcommit 4245467a03bf38906e0c1d8869af461f0c4e9338[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Mon Feb 20 21:58:57 2017 +0800
+
+    refact(src/main/java/org/wang/tools/controller/ToolsController.java): clause of sql wheth there is or not district_ids, dept_ids, class_ids to use store_group, store_id, cat1_id.
+
+[33mcommit 3d29c162e42812c969856ae9ba180bc0abae3491[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Sat Feb 18 22:18:43 2017 +0800
+
+     feath: 1.display sql excuted on web. 2. get data from pre-kpi table based on group of authority.
+
+[33mcommit 87d4cc0056bebcd2f342fe6dd3591fc7c62dd9e5[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Sat Feb 18 10:59:41 2017 +0800
+
+    feath: check wheth group of user with problem has or no report
+
+[33mcommit cb0662176cfb911e8295659fceeaecb42e0df3bc[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Sat Feb 18 09:43:57 2017 +0800
+
+     add analysis of data preblem
+
+[33mcommit c6af3f40faddcca8ff9d2560f8be1c89bbb19d87[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Sat Feb 18 09:41:58 2017 +0800
+
+    add analysis of data problem
+
+[33mcommit 7da9f86730716698a2157a702e1e617ea94cace2[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Sat Jul 9 01:05:35 2016 +0800
+
+    refactor(ExcelReader.java/importSome.xml/ColProperty.java):
+    
+    reconsitute implementation of generate sql script.
+    
+    firstly , foreach every one column and find its relation  index  in
+    excel.
+
+[33mcommit 020d146d6645e2b7628b806a2082df653406382c[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Thu Jul 7 21:49:04 2016 +0800
+
+    feat(ColumnLoader.java,ExcelReader.java,importSome.xml,ColPropert.java):
+    
+    generate insert script based on excel .
+
+[33mcommit b10b68db35acb5e67247553102992e687519008f[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Mon Jul 4 10:28:40 2016 +0800
+
+    1.order dishe.
+
+[33mcommit 97cfa5c9053613363a8722af8bfcaab87089b176[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Tue Jun 28 23:44:51 2016 +0800
+
+    fix(ETLScriptGenerator.jsp):
+    add sourceDatabase and targetDatabase select
+
+[33mcommit 783f081abb3460fc78cabe176cc52d7c1c765108[m
+Merge: 7467f5b 7a5b2e6
+Author: thinkinerp <903784816@qq.com>
+Date:   Mon Jun 27 15:54:33 2016 +0800
+
+    Merge branch 'master' of https://github.com/thinkinerp/tool.git
+    
+    Conflicts:
+            src/main/webapp/ETLScriptGenerator.jsp
+            src/main/webapp/js/comboboxConfig.js
+
+[33mcommit 7467f5b59b7ff6c4e7ebba8885207137406b8fcb[m
+Author: thinkinerp <903784816@qq.com>
+Date:   Mon Jun 27 15:52:46 2016 +0800
+
+    solve conflicts
+
+[33mcommit 7a5b2e6e01beae7242e7542fa997405098da88c0[m
+Author: bd <903784816@qq.com>
+Date:   Sun Jun 26 18:15:35 2016 +0800
+
+    fix bugs including:
+    
+    1.generating sql script without target table and source table .
+    
+    2.generating concat type column.
+
+[33mcommit 664edec93ffa653d82437bbd5c7f638e9b10a417[m
+Author: bd <903784816@qq.com>
+Date:   Sun Jun 26 14:53:19 2016 +0800
+
+    basic version:
+    
+    features including:
+    
+    1.generate etl sql , including Configration of date , authority.
+    
+    2.combobox for source table , target table .
+    
+    3.navigation of sql paragam .
+
+[33mcommit 663bbda81cefafd33c7c9ae979e7e9a2cc750871[m
+Author: thinkinerp <thinkinerp@users.noreply.github.com>
+Date:   Sun Jun 19 02:59:54 2016 +0800
+
+    Create README.md
+
+[33mcommit ea14e243437882b2db809e813bc12b7190f51a3b[m
+Author: bd <903784816@qq.com>
+Date:   Sun Jun 19 01:03:44 2016 +0800
+
+    new featrue: dymatically ,  getting names of tables , and evaluate the
+    sourceTable and targetTable of sql sections
+
+[33mcommit 67fb2dbde4a7779e738ec8bd56884f55921e0095[m
+Author: bd <903784816@qq.com>
+Date:   Sun Jun 19 00:04:15 2016 +0800
+
+    权限的配置代码。
+
+[33mcommit 1e3397c10b5713f96019cd386d006bf2a768e4fb[m
+Author: bd <903784816@qq.com>
+Date:   Thu Jun 16 14:14:34 2016 +0800
+
+    test
+
+[33mcommit 94eb015916781e59ad946af1e5a0d0647836a6c7[m
+Author: good good study , day day up. <903784816@qq.com>
+Date:   Thu Jun 16 13:04:41 2016 +0800
+
+    init test
+
+[33mcommit 184ca2e22b3270c308a5bc0191a843a05f63dc3a[m
+Author: good good study , day day up. <903784816@qq.com>
+Date:   Fri Jun 10 17:15:59 2016 +0800
+
+    test

--- a/src/main/webapp/sjt/installDetails.html
+++ b/src/main/webapp/sjt/installDetails.html
@@ -75,7 +75,7 @@
                             <div class="iz-list-title">打印机编号</div>
                             <div class="iz-list-content" id = "printCode"></div>
                         </li>
-                        <li>
+                        <li >
                             <div class="iz-list-title">采集点编号</div>
                             <div class="iz-list-content" id = "equipmentCode"></div>
                         </li>
@@ -154,7 +154,7 @@
                 <!-- 安装详情3(收银机信息) -->
                 <div class="swiper-slide">
                     <ul class="g-importList">
-                        <li>
+                        <li style="display:none">
                             <div class="g-importList-title">收银机编号</div>
                             <div class="g-importList-content">
                                 <div class="i-import">
@@ -210,7 +210,7 @@
                 <!-- 安装详情4(打印机信息) -->
                 <div class="swiper-slide">
                     <ul class="g-importList">
-                        <li>
+                        <li style="display:none">
                             <div class="g-importList-title">打印机编号</div>
                             <div class="g-importList-content">
                                 <div class="i-import">
@@ -248,7 +248,7 @@
                 <!-- 安装详情5(采集点信息) -->
                 <div class="swiper-slide">
                     <ul class="g-importList">
-                        <li>
+                        <li style="display:none">
                             <div class="g-importList-title">采集点编号</div>
                             <div class="g-importList-content">
                                 <div class="i-import">
@@ -283,7 +283,7 @@
                             </div>
                         </li>
                         <li>
-                            <div id="softCodeOrVersion" class="g-importList-title">硬件编号/软件版本</div>
+                            <div id="softCodeOrVersion" class="g-importList-title">硬件编号</div>
                             <div class="g-importList-content">
                                 <div class="i-import">
                                     <input id = "softwareVersion" type="text" placeholder="请输入" />
@@ -503,13 +503,7 @@
                 submit();              
 
             }
-       /*===返回 end===*/
-         // $("#eqTypeHard").click(function(){
-         //        $("#softCodeOrVersion").html("硬件编号"); 
-         // });
-         // $("#eqTypeSoft").click(function(){
-         //        $("#softCodeOrVersion").html("软件版本"); 
-         // });
+       /*===返回 end===*/         
         </script>
 
 <!-- <script src="js/buttonAway.js" type="text/javascript" charset="utf-8"></script> -->

--- a/src/main/webapp/sjt/issueDetails.html
+++ b/src/main/webapp/sjt/issueDetails.html
@@ -825,7 +825,8 @@
                     if(form_empty({code:$('#sp1').html(), which:"项目名称"}))
                         {return;}
                     if(form_empty({code:$('#sp2').html(), which:"商铺名称"}))
-                        {return;}
+                        {swiper2.slideTo(1, 0, true);
+                         return;}
                 $.when(codeUnique({
                     tableName : "problem",
                     codeField : "problem_id",

--- a/src/main/webapp/sjt/issueDetails.html
+++ b/src/main/webapp/sjt/issueDetails.html
@@ -46,7 +46,7 @@
                 <div class="swiper-slide">
                     解决方案
                 </div>
-                <div class="swiper-slide">
+                <div class="swiper-slide"  id="swiper-memo1">
                     批注
                 </div>
             </div>
@@ -86,9 +86,7 @@
                             </div>
                             <div class="g-importList-content">
                                 <div class="i-xiala-list">
-                                    <div id="gs3" alertTitle="跟踪方" data-select="海鼎,客户">
-
-                                    </div>
+                                    <div id="gs3" alertTitle="跟踪方" data-select="海鼎,客户">海鼎</div>
                                 </div>
                             </div>
                         </li>
@@ -98,9 +96,7 @@
                             </div>
                             <div class="g-importList-content">
                                 <div class="i-xiala-list">
-                                    <div  id="gs4" class="on"  alertTitle="问题类型">
-
-                                    </div>
+                                    <div  id="gs4" class="on"  alertTitle="问题类型">运维</div>
                                 </div>
                             </div>
                         </li>
@@ -110,7 +106,7 @@
                             </div>
                             <div class="g-importList-content">
                                 <div class="i-xiala-list">
-                                    <div id="gs5" class="on" alertTitle="跟进人">
+                                    <div id="gs5" class="gs-selperson on" alertTitle="跟进人">
 
                                     </div>
                                 </div>
@@ -193,7 +189,7 @@
                             </div>
                             <div class="g-importList-content">
                                 <div class="i-date">
-                                    <input id="ms1" type="date" placeholder="未选择" onblur="app.dateVerify(this,1)"/>
+                                    <input id="ms1" type="date" placeholder="未选择"/>
                                 </div>
                             </div>
                         </li>
@@ -203,7 +199,7 @@
                             </div>
                             <div class="g-importList-content">
                                 <div class="i-date">
-                                    <input  id="ms2" type="date" placeholder="未选择" onblur="app.dateVerify(this,1)"/>
+                                    <input  id="ms2" type="date" placeholder="未选择"/>
                                 </div>
                             </div>
                         </li>
@@ -213,7 +209,7 @@
                             </div>
                             <div class="g-importList-content">
                                 <div class="i-date">
-                                    <input  id="ms3" type="date" placeholder="未选择" onblur="app.dateVerify(this,2)"/>
+                                    <input  id="ms3" type="date" placeholder="未选择"/>
                                 </div>
                             </div>
                         </li>
@@ -233,7 +229,7 @@
                             </div>
                             <div class="g-importList-content">
                                 <div class="i-date">
-                                    <input  id="ms5" type="date"  placeholder="未选择" onblur="app.dateVerify(this,2)"/>
+                                    <input  id="ms5" type="date"  placeholder="未选择"/>
                                 </div>
                             </div>
                         </li>
@@ -287,7 +283,7 @@
                 <div class="swiper-slide">
                     <textarea class="i-contenteditable textarea-text1" placeholder="请输入解决方案"  id="jjfa" contenteditable="true" style="height:3.4rem;"></textarea>
                 </div>
-                <div class="swiper-slide">
+                <div class="swiper-slide" id="swiper-memo2">
                     <textarea class="i-contenteditable textarea-text1" contenteditable="true"  placeholder="请输入批注" id ="messageContext"></textarea>
                     <div class="i-contenteditable-ok" id = "saveMessage">
                         添加批注
@@ -488,7 +484,7 @@
                 gs1 : null, //问题编号
                 gs2 : null, //问题状态
                 gs3 : '海鼎', //跟进方
-                gs4 : null, //问题类型
+                gs4 : '运维', //问题类型
                 gs5 : null, //跟进人
                 gs6 : null, //跟进部门
                 gs7 : null, //问题标签
@@ -596,10 +592,12 @@
                         success : function(data) {
                             var text = ''
                             for (var i = 0; i < data.length; i++) {
+                                if(data[i].department!=""&&data[i].department!="undefined")
+                                {var datadep="-"+data[i].department;}
                                 if (i == data.length - 1) {
-                                    text += data[i].userName
+                                    text += data[i].userName+datadep;
                                 } else {
-                                    text += data[i].userName + ','
+                                    text += data[i].userName+datadep+ ','
                                 }
                                 selectdeparr.push(data[i].department);
                             }
@@ -798,7 +796,7 @@
                     ,
                     'problem.problemObject' : $("#gs3").html()//跟踪方
                     ,
-                    'problem.problemDepartment' : gs.gs6//跟踪部门
+                    'problem.problemDepartment' :$("#gs6").html()//跟踪部门
                     ,
                     'problem.problemUser' : gs.gs5//跟踪人
                     ,
@@ -1012,6 +1010,9 @@
                 var problemId = app.getUrlSearch("problemId");
                 problemtestId=problemId;
                 if (problemId == null) {// 新建
+                    $(".swiper-container1").find("#swiper-memo1").hide();
+                    $(".swiper-container2").find("#swiper-memo2").hide();
+                   // $(".swiper-container2").find(".swiper-slide").eq(5).hide();
                     sp.init();
                     gs.init();
                     var time = new Date().getTime();                    
@@ -1057,8 +1058,7 @@
                     app.fullImg(i);
                 })
                 //img end
-            })
-            swiper1 = new Swiper('.swiper-container1', {//菜单区滑块
+                 swiper1 = new Swiper('.swiper-container1', {//菜单区滑块
                 paginationClickable : true,
                 slidesPerView : 'auto',
                 freeMode : true
@@ -1073,6 +1073,8 @@
                     app.upStyle(swiper.activeIndex);
                 }
             });
+            })
+           
 
             var onGs3Click = function() {
                 if ('海鼎' == $("#gs3").html()) {

--- a/src/main/webapp/sjt/issueList.html
+++ b/src/main/webapp/sjt/issueList.html
@@ -271,7 +271,7 @@
 					   			dom.push('<p>'+data[i].state+'</p>');
 					   			dom.push('</div>');
 					   			dom.push('<div class="content-row">');
-					   			dom.push('<p>更新时间</p>');
+					   			dom.push('<p>最后修改时间</p>');
 					   			dom.push('<p>'+data[i].updatedAt+'</p>');
 					   			dom.push('</div>');
 					   			dom.push('</div>');

--- a/src/main/webapp/sjt/js/comUtil.js
+++ b/src/main/webapp/sjt/js/comUtil.js
@@ -20,8 +20,7 @@ var readOnly = function(id){
 }
 function form_empty(config){
     if(config.code==""  )
-    {
-    	app.alert(config.which+":"+config.code + ",不能为空",1);
+    {app.alert(config.which+":"+config.code + ",不能为空",1);
 	 return true;
     }
     else if(config.which="商铺名称")

--- a/src/main/webapp/sjt/js/global.js
+++ b/src/main/webapp/sjt/js/global.js
@@ -456,15 +456,19 @@ function removeByValue(arr, val) {
 function chk_brand(dyjbrand,dyjxh,dyjPort,obj)
 { if((dyjbrand!=""&&dyjbrand!="未选择") || (dyjxh!=""&&dyjxh!="未选择") || (dyjPort!=""&&dyjPort!="未选择") )
 				 {
-				   if (form_empty({code:$(obj).val(), which:"收银机编号"}))
-				   {return true;}
+				   if (form_empty({code:$(obj).val(),which:"收银机编号"}))
+				   {swiper2.slideTo(2, 0, true);
+				   	$("#g-popupOk").bind("click",function(){ $(obj).focus();})           			
+				   	return true;}
 			     }
 }
 function chk_print(dyjbrand,dyjxh,dyjPort,obj)
 { if((dyjbrand!=""&&dyjbrand!="未选择") || (dyjxh!=""&&dyjxh!="未选择") || (dyjPort!=""&&dyjPort!="未选择") )
 				 { 
 				   if (form_empty({code:$(obj).val(), which:"打印机编号"}))
-				   {return true;}
+				   {swiper2.slideTo(3, 0, true);
+           			$("#g-popupOk").bind("click",function(){ $(obj).focus();})          
+				   	return true;}
 			     }
 }
 
@@ -474,6 +478,8 @@ function chk_equipment(){
 			|| ($("softwareVersion").html() == "未选择" &&  $("softwareVersion").html() == "")
 			|| ("" == $("#installTime").val() && "未选择" == $("#installTime").val())){
 		  if(form_empty({code:$("#eqId").val(), which:"采集点编号"})){
+		  	 swiper2.slideTo(4, 0, true);
+		  	 $("#g-popupOk").bind("click",function(){   $("#eqId").focus();}) 
 			  return true ;
 		  }else{
 			  return false;

--- a/src/main/webapp/sjt/js/global.js
+++ b/src/main/webapp/sjt/js/global.js
@@ -40,7 +40,7 @@ var m_loading = {
 
 		}
 	}
-
+var hasperson=false;
 var app ={
 	listdata:'', //选择列表数据
 	put:'', 	//选择后要显示的位置
@@ -84,10 +84,12 @@ var app ={
 	select:function(obj,type,fun){ //obj(有data-select的那个标签,传this 例如 app.select(this))    type: 1只能选择   2可以选择也可以输入 输入匹配   3可以选择可以输入 输入匹配 并可选择没匹配项
 		/*===隐藏原生标题栏 start1===*/
 		// window.SYP.toggleShowBanner('hidden');
-		/*===隐藏原生标题栏 end1===*/
+		/*===隐藏原生标题栏 end1===*/		    
 			app.put = obj;
 			objid=obj.id;
 			app.selecttype = type;
+			if($(obj).hasClass("gs-selperson"))
+			{hasperson=true;}
 			if(fun != undefined && fun != '' && fun != null){	
 				app.selectOverFun = fun;
 			}
@@ -179,7 +181,10 @@ var app ={
     	var ls;
     	$("#g-select-list li").click(function(){
         	$(this).addClass('on').siblings('li').removeClass('on');
-        	 ls = $(this).html();        	   
+        	 ls = $(this).html(); 
+        	 if(hasperson)
+        	 {ls=ls.split("-")[0];}
+
         	setTimeout(function(){
         		$(app.put).html(ls);
         		$(app.put).removeClass('on');
@@ -190,7 +195,14 @@ var app ={
 				/*===显示原生标题栏 end===*/
         		if(app.selectOverFun != undefined && app.selectOverFun != '' && app.selectOverFun != null){
 					app.selectOverFun();
-				}
+				}				
+				if(objid=="eqTypeHard")
+				{
+					if ($("#eqTypeHard").html()=="硬件数据通")
+		             {$("#softCodeOrVersion").html("硬件编号"); }
+		           else
+		          	{$("#softCodeOrVersion").html("软件版本"); }
+		      }
         	},300)
         	/*===问题列表 start===*/
 

--- a/src/main/webapp/sjt/js/install.js
+++ b/src/main/webapp/sjt/js/install.js
@@ -72,13 +72,17 @@ var shopStateSeach = function(){
 	 						"						<p>采集接口类型</p>" +
 	 						"						<p>"+(undefined == item.eqType?"":item.eqType)+"</p>" +
 	 						"					</div>" +
-	 						"					<div class='content-row'>" +
-	 						"						<p>收银机编号</p>" +
-	 						"						<p>"+(undefined == item.cashSystem?"":item.cashId)+"</p>" +
-	 						"					</div>" +
+	 						// "					<div class='content-row'>" +
+	 						// "						<p>收银机编号</p>" +
+	 						// "						<p>"+(undefined == item.cashSystem?"":item.cashId)+"</p>" +
+	 						// "					</div>" +
 	 						"					<div class='content-row'>" +
 	 						"						<p>采集方式</p>" +
 	 						"						<p>"+(undefined == item.cashSystem?"":item.eqStyle)+"</p>" +
+	 						"					</div>" +
+	 						"					<div class='content-row'>" +
+	 						"						<p>最后操作时间</p>" +
+	 						"						<p>"+(undefined == item.installEndtime?"":item.installEndtime)+"</p>" +
 	 						"					</div>" +
 	 						"				</div>"
 	 					

--- a/src/main/webapp/sjt/js/installDetails.js
+++ b/src/main/webapp/sjt/js/installDetails.js
@@ -274,7 +274,13 @@ var loadInstall = function(allThing){
         console.log(allObjs.equipment.eqType);
         $("#eqTypeHard").html(isUndefined(allObjs.equipment.eqType));
         $('#eqStyle').html(isUndefined(allObjs.equipment.eqStyle));
-        $('#softwareVersion').val(isUndefined(allObjs.equipment.softwareVersion));
+        var software_txt;
+        if(isUndefined(allObjs.equipment.softwareVersion))
+            {software_txt=allObjs.equipment.softwareVersion;}
+         if(isUndefined(allObjs.equipment.hardwareId))
+            {software_txt=allObjs.equipment.hardwareId;}
+
+        $('#softwareVersion').val(software_txt);
         /* $('#installTime').val(isUndefined(allObjs.equipment.installTime)); */
         
         //其他
@@ -568,8 +574,8 @@ var submit = function() {
         'equipment.eqStyle': $("#eqStyle").html()
           //          ,'hardwareId':
           ,
-        'equipment.softwareVersion': ($('#eqTypeSoft').attr('class') == "on" ? $('#softwareVersion').val():""),
-        'equipment.hardwareId': ($('#eqTypeHard').attr('class') == "on" ? $('#softwareVersion').val():""),
+        'equipment.softwareVersion': ($('#eqTypeHard').html()!="硬件数据通" ? $('#softwareVersion').val():""),
+        'equipment.hardwareId': ($('#eqTypeHard').html()=="硬件数据通"? $('#softwareVersion').val():""),
         'equipment.proId': allObjs.project.proId,
         'equipment.shopId': $('#shopCode').html(),
         'userName': params.userName,
@@ -607,17 +613,17 @@ var submit = function() {
          var cashSystem_txt=$("#cashSystem").html();
          var cashBrand_txt=$("#cashBrand").html();
          var cashPort_txt=$("#cashPort").html();
-        if(chk_brand(cashSystem_txt,cashBrand_txt,cashPort_txt,"#cashId"))
-          {return;}
-        var priBrand_txt=$("#priBrand").val();
-         var dyjxh_txt=$("#dyjxh").html();
-         var dyjPort_txt=$("#printerPort").html();
-        if(chk_print(priBrand_txt,dyjxh_txt,dyjPort_txt,"#priId"))
-          {return;}
+        // if(chk_brand(cashSystem_txt,cashBrand_txt,cashPort_txt,"#cashId"))
+        //   {return;}
+        // var priBrand_txt=$("#priBrand").val();
+        //  var dyjxh_txt=$("#dyjxh").html();
+        //  var dyjPort_txt=$("#printerPort").html();
+        // if(chk_print(priBrand_txt,dyjxh_txt,dyjPort_txt,"#priId"))
+        //   {return;}
         
-        if(chk_equipment()){
-        	return ;
-        }
+        // if(chk_equipment()){
+        // 	return ;
+        // }
         
          //验证收银机编号和打印机编号 end 
 	 $.when(
@@ -627,28 +633,7 @@ var submit = function() {
 								         ,code:$('#installCode').val()
 								         , which:"安装编码"
 								        ,extra:true
-	 				} )
-			      ,codeUnique({
-			 		 tableName:"cash"
-				         ,codeField:"cash_id"
-				         ,code:$('#cashId').val()
-				         , which:"收银机编号"
-				        ,extra:chk_brand(cashSystem_txt,cashBrand_txt,cashPort_txt,"#cashId")
-		} )
-			      ,codeUnique({
-			 		 tableName:"printer"
-				         ,codeField:"printer_id"
-				         ,code:$('#priId').val()
-				         , which:"打印机编号"
-				        ,extra:chk_print(priBrand_txt,dyjxh_txt,dyjPort_txt,"#priId")
-		} )
-			      ,codeUnique({
-			 		 tableName:"equipment"
-				         ,codeField:"eq_id"
-				         ,code:$('#eqId').val()
-				         , which:"采集点编码"
-				         ,extra:chk_equipment()
-		} )
+	 				} )			      
             )
 	 .done(function(){ 
 
@@ -709,7 +694,8 @@ var submit = function() {
         'equipment.eqStyle': $("#eqStyle").html()
           //          ,'hardwareId':
           ,
-        'equipment.softwareVersion': $('#softwareVersion').val(),
+         'equipment.softwareVersion': ($('#eqTypeHard').html()!="硬件数据通" ? $('#softwareVersion').val():""),
+        'equipment.hardwareId': ($('#eqTypeHard').html()=="硬件数据通"? $('#softwareVersion').val():""),
         'equipment.proId': $('#proName').html(),
         'equipment.shopId': $('#shopCode').html(),
         'userName': params.userName,

--- a/src/main/webapp/sjt/js/installDetails.js
+++ b/src/main/webapp/sjt/js/installDetails.js
@@ -602,7 +602,8 @@ var submit = function() {
     if(form_empty({code:$('#proName').html(), which:"项目名称"}))
       {return;}
     if(form_empty({code:$('#shopName').html(), which:"商铺名称"}))
-      {return;}
+      {swiper2.slideTo(1, 0, true);
+        return;}
      //验证收银机编号和打印机编号 start
          var cashSystem_txt=$("#cashSystem").html();
          var cashBrand_txt=$("#cashBrand").html();
@@ -615,7 +616,7 @@ var submit = function() {
         if(chk_print(priBrand_txt,dyjxh_txt,dyjPort_txt,"#priId"))
           {return;}
         
-        if(chk_equipment()){
+        if(chk_equipment()){          
         	return ;
         }
         

--- a/src/main/webapp/sjt/surveyDetails.html
+++ b/src/main/webapp/sjt/surveyDetails.html
@@ -119,7 +119,7 @@
 				</div>
 				<div class="swiper-slide">
 					<ul class="g-importList">
-						<li>
+						<li style="display:none">
 							<div class="g-importList-title">收银机编号</div>
 							<div class="g-importList-content">
 								<div class="i-import">
@@ -170,7 +170,7 @@
 				</div>
 				<div class="swiper-slide">
 					<ul class="g-importList">
-				    	<li>
+				    	<li style="display:none">
 				    		<div class="g-importList-title">打印机编号</div>
 				    		<div class="g-importList-content">
 				    			<div class="i-import">
@@ -648,16 +648,16 @@
 				 if(form_empty({code:$('#shopName').html(), which:"商铺名称"}))
 				 	{return;}
 				 //验证收银机编号和打印机编号 start
-				 var syjSystem_txt=$("#syjSystem").html();
-				 var syjBrand_txt=$("#syjBrand").html();
-				 var syjPort_txt=$("#syjPort").html();
-				if(chk_brand(syjSystem_txt,syjBrand_txt,syjPort_txt,"#syjId"))
-					{return;}
-				var dyjbrand_txt=$("#dyjbrand").val();
-				 var dyjxh_txt=$("#dyjxh").html();
-				 var dyjPort_txt=$("#dyjPort").html();
-				if(chk_print(dyjbrand_txt,dyjxh_txt,dyjPort_txt,"#dyjId"))
-					{return;}
+				//  var syjSystem_txt=$("#syjSystem").html();
+				//  var syjBrand_txt=$("#syjBrand").html();
+				//  var syjPort_txt=$("#syjPort").html();
+				// if(chk_brand(syjSystem_txt,syjBrand_txt,syjPort_txt,"#syjId"))
+				// 	{return;}
+				// var dyjbrand_txt=$("#dyjbrand").val();
+				//  var dyjxh_txt=$("#dyjxh").html();
+				//  var dyjPort_txt=$("#dyjPort").html();
+				// if(chk_print(dyjbrand_txt,dyjxh_txt,dyjPort_txt,"#dyjId"))
+				// 	{return;}
                  //验证收银机编号和打印机编号 end  
                  if(shop.item)
                  {
@@ -723,20 +723,6 @@
                                          ,code:$('#dyid').val()
                                          , which:"调研编码"
                                          ,extra:true
-                    } ),
-                    codeUnique({
-                                           tableName:"cash"
-                                         ,codeField:"cash_id"
-                                         ,code:$('#syjId').val()
-                                         , which:"收银机编码"
-                                         ,extra:chk_brand(syjSystem_txt,syjBrand_txt,syjPort_txt,"#syjId")
-                    } ),
-                    codeUnique({
-                                           tableName:"printer"
-                                         ,codeField:"printer_id"
-                                         ,code:$('#dyjId').val()
-                                         , which:"打印机编码"
-                                         ,extra:chk_print(dyjbrand_txt,dyjxh_txt,dyjPort_txt,"#dyjId")
                     } )
                     ).done(function(){
 					   

--- a/src/main/webapp/sjt/surveyDetails.html
+++ b/src/main/webapp/sjt/surveyDetails.html
@@ -646,7 +646,8 @@
 				 if(form_empty({code:$('#itemName').html(), which:"项目名称"}))
 				 	{return;}
 				 if(form_empty({code:$('#shopName').html(), which:"商铺名称"}))
-				 	{return;}
+				 	 {swiper2.slideTo(1, 0, true);
+        		return;}
 				 //验证收银机编号和打印机编号 start
 				 var syjSystem_txt=$("#syjSystem").html();
 				 var syjBrand_txt=$("#syjBrand").html();


### PR DESCRIPTION
- 收银机编号、打印机编号、采集点编号海鼎确认是的需要隐藏
    - 页面上不显示这三个编号，后台自动生成-隐藏，检查为空去掉-完成
- 安装：最后操作时间；问题：最后修改时间 -完成
- 问题模块在选择人员的时候在名称后加上部门名称-完成
- 问题模块所有的时间取消限制（提出时间、预计解决时间等）-完成
- 新建问题的时候：批准不显示-完成
- 新建问题，问题类型：默认海鼎运维-完成
- 客情关系：固定（优先、良好等，待海鼎）
    - 数据库中项目表添加一个字段：客情关系
    - 关系等级在页面上固定-客户对接人下面，还没有按星星显示
- 硬件编号/软件版本分开传值
