### PR TITLE
2017-09-04 fix

### DIFF
--- a/src/main/webapp/sjt/installDetails.html
+++ b/src/main/webapp/sjt/installDetails.html
@@ -81,15 +81,23 @@
                             <div class="iz-list-title">安装状态</div>
                             <div class="iz-list-content" id = "installStation"></div>
                         </li>
+                        <li style="margin-top:0">
+                            <div class="iz-list-title" style="margin-top:0.3rem;">数据精准度</div>
+                            <div class="iz-list-content" ><div class="i-xiala" style="margin-top:0px;margin-left:0px;">
+                                <div class="i-xiala-list">
+                                    <div id = 'installData' alertTitle="数据精准度" data-select="" onclick="app.select(this,2)"></div>
+                                </div>
+                            </div></div>
+                        </li>
                     </ul>
-                    <div class="iz-title">
+                  <!--   <div class="iz-title">
                         <div>数据精准度</div>
                     </div>
                     <div class="i-xiala">
                         <div class="i-xiala-list">
                             <div id = 'installData' alertTitle="数据精准度" data-select="" onclick="app.select(this,2)"></div>
                         </div>
-                    </div>
+                    </div> -->
                 </div>
                 <!--end安装详情1(安装概述)-->
                 <!-- 安装详情2(商铺信息) -->

--- a/src/main/webapp/sjt/js/comUtil.js
+++ b/src/main/webapp/sjt/js/comUtil.js
@@ -21,7 +21,7 @@ var readOnly = function(id){
 function form_empty(config){
 	m_loading.remove();
     if(config.code==""  )
-    {app.alert(config.which+":"+config.code + ",不能为空",1);
+    {app.alert(config.which+":"+config.code + "不能为空",1);
 	 return true;
     }
     else if(config.which="商铺名称")

--- a/src/main/webapp/sjt/js/installDetails.js
+++ b/src/main/webapp/sjt/js/installDetails.js
@@ -299,10 +299,16 @@ var loadInstall = function(allThing){
         //     $('#eqTypeHard').attr("class",'off');
         //     $('#eqTypeSoft').attr("class",'on');
         // }
-        console.log(allObjs.equipment.eqType);
+       
         $("#eqTypeHard").html(isUndefined(allObjs.equipment.eqType));
         $('#eqStyle').html(isUndefined(allObjs.equipment.eqStyle));
         var software_txt;
+        if($("#eqTypeHard").html()=="硬件数据通")
+          {$("#softCodeOrVersion").html("硬件编号");}
+        else if($("#eqTypeHard").html()=="软件数据通")
+          {$("#softCodeOrVersion").html("软件版本");}
+        else
+          {$("#softCodeOrVersion").parents("li").css("display","none");}
         if(isUndefined(allObjs.equipment.softwareVersion))
             {software_txt=allObjs.equipment.softwareVersion;}
          if(isUndefined(allObjs.equipment.hardwareId))
@@ -633,7 +639,7 @@ var submit = function() {
         'equipment.eqStyle': $("#eqStyle").html()
           //          ,'hardwareId':
           ,
-        'equipment.softwareVersion': ($('#eqTypeHard').html()!="硬件数据通" ? $('#softwareVersion').val():""),
+        'equipment.softwareVersion': ($('#eqTypeHard').html()=="软件数据通" ? $('#softwareVersion').val():""),
         'equipment.hardwareId': ($('#eqTypeHard').html()=="硬件数据通"? $('#softwareVersion').val():""),
         'equipment.proId':( undefined == allObjs.project?"":allObjs.project.proId),
         'equipment.shopId': $('#shopCode').html(),
@@ -743,7 +749,7 @@ var submit = function() {
         'equipment.eqStyle': $("#eqStyle").html()
           //          ,'hardwareId':
           ,
-         'equipment.softwareVersion': ($('#eqTypeHard').html()!="硬件数据通" ? $('#softwareVersion').val():""),
+         'equipment.softwareVersion': ($('#eqTypeHard').html()=="软件数据通" ? $('#softwareVersion').val():""),
         'equipment.hardwareId': ($('#eqTypeHard').html()=="硬件数据通"? $('#softwareVersion').val():""),
         'equipment.proId': $('#proName').html(),
         'equipment.shopId': $('#shopCode').html(),

--- a/src/main/webapp/sjt/js/installDetails.js
+++ b/src/main/webapp/sjt/js/installDetails.js
@@ -566,6 +566,10 @@ var submit = function() {
         {swiper2.slideTo(4, 0, true); 
         return;
          }   
+         if(form_empty({code:$('#installTime').val(), which:"安装日期"}))
+        {swiper2.slideTo(4, 0, true); 
+        return;
+         }   
          if(form_empty({code:$('#priBrand').val(), which:"打印机品牌"}))
         {swiper2.slideTo(3, 0, true);
            $("#g-popupOk").bind("click",function(){ $('#priBrand').focus();})  


### PR DESCRIPTION
新建安装信息，安装日期没有填没有提示信息
弹出提示改进
在安装详情页面，安装采集接口类型“软件数据通”对应显示的是"软件版本"，现在显示的是“硬件编号”
安装详情页面，安装概述栏的“数据精准度”和相应的选择下拉框各占一行，为适应整体风格，将选择下拉框放在“数据精准度”右侧同一行